### PR TITLE
Support clr-namespace for namespace declaration as well

### DIFF
--- a/OmniXaml/TypeLocation/TypeDirectory.cs
+++ b/OmniXaml/TypeLocation/TypeDirectory.cs
@@ -6,6 +6,7 @@
 
     public class TypeDirectory : ITypeDirectory
     {
+        private static readonly List<string> namespaceDeclarations = new List<string> { "using:", "clr-namespace:" };
         private readonly ISet<XamlNamespace> xamlNamespaces;
 
         public TypeDirectory(IEnumerable<XamlNamespace> xamlNamespaces)
@@ -42,8 +43,6 @@
 
         private static bool IsClrNamespace(string ns)
         {
-            var namespaceDeclarations = new List<string>{ "using:", "clr-namespace:" };
-
             return namespaceDeclarations.Exists(decl => ns.StartsWith(decl));
         }
     }

--- a/OmniXaml/TypeLocation/TypeDirectory.cs
+++ b/OmniXaml/TypeLocation/TypeDirectory.cs
@@ -36,22 +36,15 @@
             {
                 return TypeLocation.ClrNamespace.ExtractNamespace(name);
             }
-                
+
             return xamlNamespaces.FirstOrDefault(xamlNamespace => xamlNamespace.Name == name);
         }
 
         private static bool IsClrNamespace(string ns)
         {
-            var namespaceDeclarations = new string[] { "using:", "clr-namespace:" };
-            foreach (var decl in namespaceDeclarations)
-            {
-                if (ns.StartsWith(decl))
-                {
-                    return true;
-                }
-            }
+            var namespaceDeclarations = new List<string>{ "using:", "clr-namespace:" };
 
-            return false;
+            return namespaceDeclarations.Exists(decl => ns.StartsWith(decl));
         }
     }
 }

--- a/OmniXaml/TypeLocation/TypeDirectory.cs
+++ b/OmniXaml/TypeLocation/TypeDirectory.cs
@@ -6,7 +6,6 @@
 
     public class TypeDirectory : ITypeDirectory
     {
-        private const string ClrNamespace = "using:";
         private readonly ISet<XamlNamespace> xamlNamespaces;
 
         public TypeDirectory(IEnumerable<XamlNamespace> xamlNamespaces)
@@ -37,13 +36,22 @@
             {
                 return TypeLocation.ClrNamespace.ExtractNamespace(name);
             }
-
+                
             return xamlNamespaces.FirstOrDefault(xamlNamespace => xamlNamespace.Name == name);
         }
 
         private static bool IsClrNamespace(string ns)
         {
-            return ns.StartsWith(ClrNamespace);
+            var namespaceDeclarations = new string[] { "using:", "clr-namespace:" };
+            foreach (var decl in namespaceDeclarations)
+            {
+                if (ns.StartsWith(decl))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
This patch allows XAML namespace declarations to start with `clr-namespace:` as well as `using:`. This is done by simply considering `clr-namespace:` a valid namespace declaration start.